### PR TITLE
[Feature/issue-27] add: バリデーションエラー時のスタイルを追加した

### DIFF
--- a/src/assets/css/variables.css
+++ b/src/assets/css/variables.css
@@ -10,18 +10,21 @@
   --background-color-gray-pressed: #b5b5b5;
   --background-color-black: #000000;
   --background-color-skyblue: #40b3ff;
+  --background-color-error: #FFD9D9;
 
   /* ボーダー */
   --border-color-default: #dddddd;
   --border-color-white: #ffffff;
   --border-color-black: #000000;
   --border-color-skyblue: #40b3ff;
+  --border-color-error: #DD3737;
 
   /* テキスト */
   --text-default: #252525;
   --text-white: #ffffff;
   --text-gray: #aaaaaa;
   --text-skyblue: #40b3ff;
+  --text-error: #AB3B3B;
 
   /* フォント */
   --font-family: Noto Sans JP,

--- a/src/components/InputField/InputField.module.scss
+++ b/src/components/InputField/InputField.module.scss
@@ -30,4 +30,19 @@
     line-height: 1.5;
     color: var(--text-gray);
   }
+
+  &[aria-invalid="true"] {
+    background-color: var(--background-color-error);
+    border: 1px solid var(--border-color-error);
+    margin-bottom: 8px;
+  }
+}
+
+.text__error {
+  color: var(--text-error);
+  font-family: var(--font-family);
+  font-style: normal;
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 1.5;
 }

--- a/src/components/InputField/InputField.tsx
+++ b/src/components/InputField/InputField.tsx
@@ -21,11 +21,12 @@ export function InputField(props: InputFieldProps) {
       <input
         {...register(props.name)}
         className={styles.input}
+        aria-invalid={errors[props.name] ? "true" : "false"}
         type="text"
         placeholder={`${props.label}を入力してください`}
       />
       {errors[props.name] && (
-        <p>{errors[props.name]?.message as string}</p>
+        <p className={styles.text__error}>{errors[props.name]?.message as string}</p>
       )}
     </div>
   );

--- a/src/components/InputPasswordField/InputPasswordField.tsx
+++ b/src/components/InputPasswordField/InputPasswordField.tsx
@@ -26,6 +26,7 @@ export function InputPasswordField(props: InputPasswordFieldProps) {
         <input
           {...register(props.name)}
           className={styles.input}
+          aria-invalid={errors[props.name] ? "true" : "false"}
           type={type}
           placeholder={`${props.label}を入力してください`}
         />
@@ -38,7 +39,7 @@ export function InputPasswordField(props: InputPasswordFieldProps) {
         </span>
       </div>
       {errors[props.name] && (
-        <p>{errors[props.name]?.message as string}</p>
+        <p className={styles.text__error}>{errors[props.name]?.message as string}</p>
       )}
     </div>
   );


### PR DESCRIPTION
## Ticket / Issue Number

- #27 

## 変更内容

![issue-27](https://github.com/user-attachments/assets/41d32e1f-5a30-4528-ade5-1152ca11deb2)

- バリデーションエラー時のスタイルを追加しました
- Error Color を追加しました
  - --background-color-error: `#FFD9D9`;
  - --border-color-error: `#DD3737`;
  - --text-error: `#AB3B3B`;

# 影響範囲

- ログイン画面の各入力欄
- 会員登録画面の各入力欄

## チェックリスト

- [x] SonarQubeCloudでエラーや警告が出ませんでした

## 補足

レビューをする際に見てほしい点、ローカル環境で試す際の注意点など補足事項があれば記入してください
