### PR TITLE
【Feature/issue-81】ご利用ガイド画面を作る

### DIFF
--- a/src/assets/css/color.css
+++ b/src/assets/css/color.css
@@ -56,7 +56,7 @@
   /* Background Colors */
   --background-primary: #FFFFFF;
   --background-secondary: var(--neutral-100);
-  --background-tertiary: var(--neutral-200);
+  --background-tertiary: var(--neutral-800);
 
   /* Text Colors */
   --text-primary: var(--neutral-900);

--- a/src/assets/css/color.css
+++ b/src/assets/css/color.css
@@ -84,5 +84,5 @@
   /* Border Colors */
   --border-light: var(--neutral-200);
   --border-medium: var(--neutral-300);
-  --border-dark: var(--neutral-400);
+  --border-dark: var(--neutral-900);
 }

--- a/src/components/ButtonLink/ButtonLink.module.scss
+++ b/src/components/ButtonLink/ButtonLink.module.scss
@@ -25,10 +25,5 @@
     background-color: var(--background-primary);
     border-color: var(--border-light);
     color: var(--text-on-primary-light);
-
-    &:hover {
-      opacity: 1;
-      background-color: var(--background-tertiary);
-    }
   }
 }

--- a/src/components/ButtonLink/ButtonLink.tsx
+++ b/src/components/ButtonLink/ButtonLink.tsx
@@ -5,9 +5,10 @@ import classNames from 'classnames';
 
 interface ButtonLinkProps {
   to: string;
-  text: string;
+  text?: string;
   white?: boolean;
   className?: string;
+  children?: React.ReactNode;
   onClick?: () => void;
 }
 
@@ -20,6 +21,7 @@ export function ButtonLink(props: ButtonLinkProps) {
       to={props.to}
       onClick={props.onClick}>
       {props.text}
+      {props.children}
     </Link>
   );
 }

--- a/src/components/ButtonLink/ButtonLink.tsx
+++ b/src/components/ButtonLink/ButtonLink.tsx
@@ -1,18 +1,22 @@
 
 import { Link } from 'react-router';
 import styles from './ButtonLink.module.scss';
+import classNames from 'classnames';
 
 interface ButtonLinkProps {
   to: string;
   text: string;
+  white?: boolean;
+  className?: string;
   onClick?: () => void;
 }
 
 export function ButtonLink(props: ButtonLinkProps) {
+  const convertClassName = classNames(styles.link, props.white ? styles.white : null, props.className);
 
   return (
     <Link
-      className={styles.link}
+      className={convertClassName}
       to={props.to}
       onClick={props.onClick}>
       {props.text}

--- a/src/components/FooterMenu/FooterMenu.module.scss
+++ b/src/components/FooterMenu/FooterMenu.module.scss
@@ -1,6 +1,6 @@
 .menu {
   min-width: var(--container-width);
-  background-color: var(--background-tertiary);
+  background-color: var(--secondary-600);
   padding: 35px 0;
 
   &__title {

--- a/src/components/FooterMenu/FooterMenu.tsx
+++ b/src/components/FooterMenu/FooterMenu.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router';
 
 import styles from './FooterMenu.module.scss';
+import { UserGuideForFooter } from '../UserGuideForFooter/UserGuideForFooter';
 
 export function FooterMenu() {
 
@@ -114,6 +115,7 @@ export function FooterMenu() {
             </ul>
           </div>
         </section>
+        <UserGuideForFooter />
         <div className={styles.other__links}>
           <a href="/contact" className={styles.contact__link}>
             <button className="atom-btn atom-btn-color-black atom-btn-medium atom-btn-padding-medium molecule-icon-button-icon-pos-right" color="black">

--- a/src/components/FooterMenu/FooterMenu.tsx
+++ b/src/components/FooterMenu/FooterMenu.tsx
@@ -92,25 +92,25 @@ export function FooterMenu() {
           <div className={styles.guide__links__content}>
             <ul className={styles.menu__links__main}>
               <li className={styles.menu__links__item}>
-                <a href="/guides/about" className={styles.menu__link}>はじめての方へ</a>
+                <Link to="/guide" className={styles.menu__link}>はじめての方へ</Link>
               </li>
               <li className={styles.menu__links__item}>
-                <a href="/guides/howto-buy" className={styles.menu__link}>ご購入方法</a>
+                <Link to="/guide#flow" className={styles.menu__link}>ご購入方法</Link>
               </li>
               <li className={styles.menu__links__item}>
-                <a href="/guides/delivery" className={styles.menu__link}>配送について</a>
+                <Link to="/guide#shipping" className={styles.menu__link}>配送について</Link>
               </li>
               <li className={styles.menu__links__item}>
-                <a href="/guides/payment" className={styles.menu__link}>お支払い方法</a>
+                <Link to="/guide#method" className={styles.menu__link}>お支払い方法</Link>
               </li>
               <li className={styles.menu__links__item}>
-                <a href="/guides/return" className={styles.menu__link}>返品・交換</a>
+                <Link to="/guide#return" className={styles.menu__link}>返品・交換</Link>
               </li>
               <li className={styles.menu__links__item}>
-                <a href="/guides/point" className={styles.menu__link}>NEKOYAポイント</a>
+                <Link to="/guide#register" className={styles.menu__link}>会員登録</Link>
               </li>
               <li className={styles.menu__links__item}>
-                <a href="/guides#question" className={styles.menu__link}>よくあるご質問</a>
+                <Link to="/guide" className={styles.menu__link}>よくあるご質問</Link>
               </li>
             </ul>
           </div>

--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -41,6 +41,8 @@
   }
 
   &PrimaryFunction {
+    display: flex;
+
     .items {
       margin: 0;
       padding: 0;

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -7,6 +7,7 @@ import { HeaderTextFavoriteButton } from '../HeaderTextFavoriteButton/HeaderText
 import { HeaderTextCartShoppingButton } from '../HeaderTextCartShoppingButton/HeaderTextCartShoppingButton';
 import { SearchField } from "../SearchField/SearchField";
 import { useSearch } from "../../hooks/useSearch";
+import { UserGuideButtonForHeader } from '../UserGuideButtonForHeader/UserGuideButtonForHeader';
 
 export default function Header() {
   const { word, setWord, search } = useSearch();
@@ -18,6 +19,7 @@ export default function Header() {
       </Link>
       <SearchField word={word} onChange={(value) => setWord(value)} handleSearch={search} />
       <div className={styles.headerPrimaryFunction}>
+        <UserGuideButtonForHeader />
         <ul className={styles.items}>
           <li className={styles.item}>
             <HeaderTextLoginButton />

--- a/src/components/LinkList/LinkList.module.scss
+++ b/src/components/LinkList/LinkList.module.scss
@@ -1,17 +1,22 @@
-.link {
-  &__list {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 24px;
-    margin: 0;
-    padding: 0;
-  }
+@function calc-one-column-width($column, $gap) {
+  @return calc((100% - (#{$gap} * (#{$column} - 1))) / #{$column});
+}
+
+$gap: 16px;
+
+.link__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $gap;
+  margin: 0;
+  padding: 0;
 
   &__item {
-    width: 210px;
+    width: calc-one-column-width(3, $gap);
     padding-right: 8px;
+    background-color: var(--background-primary);
     border-bottom: 1px solid var(--border-light);
-    border-radius: 4px;
+    border-radius: 2px;
     transition: all 0.2s ease;
 
     ::after {
@@ -29,10 +34,10 @@
     }
 
     &:hover {
-      background-color: var(--background-tertiary);
+      opacity: 0.8;
     }
 
-    .menu__link {
+    .link {
       position: relative;
       display: block;
       color: var(--text-on-primary-light);
@@ -40,6 +45,19 @@
       font-size: 14px;
       text-decoration: none;
       padding: 16px;
+    }
+
+    &.secondary {
+      background-color: var(--secondary-600);
+      border-bottom-color: var(--secondary-600);
+
+      ::after {
+        border-color: transparent transparent transparent var(--border-light);
+      }
+
+      .link {
+        color: var(--text-on-primary);
+      }
     }
   }
 }

--- a/src/components/LinkList/LinkList.module.scss
+++ b/src/components/LinkList/LinkList.module.scss
@@ -8,9 +8,11 @@
   }
 
   &__item {
-    width: 304px;
+    width: 210px;
     padding-right: 8px;
     border-bottom: 1px solid var(--border-light);
+    border-radius: 4px;
+    transition: all 0.2s ease;
 
     ::after {
       border-color: transparent transparent transparent var(--border-dark);
@@ -35,9 +37,9 @@
       display: block;
       color: var(--text-on-primary-light);
       font-family: var(--font-family);
-      font-size: 1.2rem;
+      font-size: 14px;
       text-decoration: none;
-      padding: 16px 0;
+      padding: 16px;
     }
   }
 }

--- a/src/components/LinkList/LinkList.tsx
+++ b/src/components/LinkList/LinkList.tsx
@@ -1,17 +1,20 @@
 import { Link } from 'react-router';
 import styles from './LinkList.module.scss';
+import classNames from 'classnames';
 
 interface LinkListProps {
-  items: { id: string, to: string, src: string, alt: string }[];
+  items: { id: string, to: string, text: string }[];
+  className?: string;
 }
 
 export function LinkList(props: LinkListProps) {
+  const convertClassName = classNames(styles.link__list, props.className);
 
   return (
-    <div className={styles.link__list}>
+    <div className={convertClassName}>
       {props.items.map((item) => (
         <div className={styles.link__item} key={item.id}>
-          <Link to={item.to} className={styles.menu__link}>{item.alt}</Link>
+          <Link to={item.to} className={styles.menu__link}>{item.text}</Link>
         </div>
       ))}
     </div>

--- a/src/components/LinkList/LinkList.tsx
+++ b/src/components/LinkList/LinkList.tsx
@@ -5,16 +5,18 @@ import classNames from 'classnames';
 interface LinkListProps {
   items: { id: string, to: string, text: string }[];
   className?: string;
+  secondary?: boolean;
 }
 
 export function LinkList(props: LinkListProps) {
   const convertClassName = classNames(styles.link__list, props.className);
+  const convertClassNameItem = classNames(styles.link__list__item, props.secondary ? styles.secondary : null);
 
   return (
     <div className={convertClassName}>
       {props.items.map((item) => (
-        <div className={styles.link__item} key={item.id}>
-          <Link to={item.to} className={styles.menu__link}>{item.text}</Link>
+        <div className={convertClassNameItem} key={item.id}>
+          <Link to={item.to} className={styles.link}>{item.text}</Link>
         </div>
       ))}
     </div>

--- a/src/components/SearchByCategory/SearchByCategory.tsx
+++ b/src/components/SearchByCategory/SearchByCategory.tsx
@@ -10,7 +10,7 @@ interface SearchByCategoryProps {
 
 export function SearchByCategory(props: SearchByCategoryProps) {
   const [iconItems,] = useState(props.items.slice(0, 6));
-  const [moreItems,] = useState(props.items.slice(6, 12));
+  const [moreItems,] = useState(props.items.slice(6, 12).map((item) => ({ ...item, to: item.to, text: item.alt })));
 
   return (
     <div className={styles.search_by_category__container}>

--- a/src/components/SectionTitle/SectionTitle.module.scss
+++ b/src/components/SectionTitle/SectionTitle.module.scss
@@ -21,4 +21,10 @@
   &.large {
     font-size: 24px;
   }
+
+  &.secondary {
+    background-color: var(--secondary-600);
+    border-left: 5px solid var(--border-light);
+    color: var(--text-on-primary);
+  }
 }

--- a/src/components/SectionTitle/SectionTitle.tsx
+++ b/src/components/SectionTitle/SectionTitle.tsx
@@ -3,6 +3,7 @@ import styles from './SectionTitle.module.scss';
 
 interface SectionTitleProps {
   text: string;
+  id?: string;
   size?: 'small' | 'medium' | 'large';
 }
 
@@ -11,7 +12,7 @@ export function SectionTitle(props: SectionTitleProps) {
   const convertClassName = classNames(styles.section__title, convertSizeStyle);
 
   return (
-    <h3 className={convertClassName}>
+    <h3 className={convertClassName} id={props.id}>
       {props.text}
     </h3>
   );

--- a/src/components/SectionTitle/SectionTitle.tsx
+++ b/src/components/SectionTitle/SectionTitle.tsx
@@ -5,11 +5,12 @@ interface SectionTitleProps {
   text: string;
   id?: string;
   size?: 'small' | 'medium' | 'large';
+  secondary?: boolean;
 }
 
 export function SectionTitle(props: SectionTitleProps) {
   const convertSizeStyle = props.size ? styles[props.size] : null;
-  const convertClassName = classNames(styles.section__title, convertSizeStyle);
+  const convertClassName = classNames(styles.section__title, convertSizeStyle, props.secondary ? styles.secondary : null);
 
   return (
     <h3 className={convertClassName} id={props.id}>

--- a/src/components/UserGuide/UserGuide.module.scss
+++ b/src/components/UserGuide/UserGuide.module.scss
@@ -8,10 +8,35 @@
 
     &__main {
       width: 100%;
+    }
 
-      &__link__list {
-        margin-bottom: 60px;
+    &__text {
+      white-space: pre-line;
+      margin-bottom: 40px;
+      line-height: 1.8;
+    }
+  }
+
+  &__section {
+    margin-bottom: 60px;
+
+    &__item {
+      margin-bottom: 32px;
+
+      &__title {
+        font-size: 1rem;
+        font-weight: 600;
+        margin-bottom: 12px;
       }
+    }
+  }
+
+  &__contact__link {
+    color: var(--color-primary, #0066cc);
+    text-decoration: underline;
+
+    &:hover {
+      text-decoration: none;
     }
   }
 }

--- a/src/components/UserGuide/UserGuide.module.scss
+++ b/src/components/UserGuide/UserGuide.module.scss
@@ -1,0 +1,17 @@
+.guide {
+  width: var(--container-width);
+  margin: 40px auto 120px;
+
+  &__content {
+    display: flex;
+    gap: 40px;
+
+    &__main {
+      width: 100%;
+
+      &__link__list {
+        margin-bottom: 60px;
+      }
+    }
+  }
+}

--- a/src/components/UserGuide/UserGuide.tsx
+++ b/src/components/UserGuide/UserGuide.tsx
@@ -1,0 +1,76 @@
+
+import { UserGuideSidebar } from '../UserGuideSidebar/UserGuideSidebar';
+import { SectionTitle } from '../SectionTitle/SectionTitle';
+import styles from './UserGuide.module.scss';
+import { LinkList } from '../LinkList/LinkList';
+import { userGuide } from '../../constants/guide';
+
+export function UserGuide() {
+
+  return (
+    <div className={styles.guide}>
+      <SectionTitle text="はじめての方へ" />
+      <div className={styles.guide__content}>
+        <UserGuideSidebar />
+        <div className={styles.guide__content__main}>
+          {userGuide.map(({ id, title, list }) => (
+            <div key={id}>
+              <div id={id}></div>
+              <SectionTitle text={title} />
+              <LinkList className={styles.guide__content__main__link__list} items={list} />
+            </div>
+          ))}
+
+          <SectionTitle text="ご注文について" id='flow' />
+          <LinkList className={styles.guide__content__main__link__list} items={[
+            { id: "/guide/order#flow", to: "/guide/order#flow", text: "商品の注文の流れについて" },
+            { id: "/guide/order#receipt", to: "/guide/order#receipt", text: "領収書・納品書について" },
+            { id: "/guide/order#security", to: "/guide/order#security", text: "セキュリティについて" },
+            { id: "/guide/order#gift", to: "/guide/order#gift", text: "ギフト対応について" },
+            { id: "/guide/order#mail", to: "/guide/order#mail", text: "メールについて" }
+          ]} />
+          <SectionTitle text="お支払いについて" id='receipt' />
+          <LinkList className={styles.guide__content__main__link__list} items={[
+            { id: "/guide/payment#method", to: "/guide/payment#method", text: "お支払い方法について" }
+          ]} />
+          <SectionTitle text="お届けについて" id='security' />
+          <LinkList className={styles.guide__content__main__link__list} items={[
+            { id: "1", to: "/guide/order#flow", text: "商品の注文の流れについて" },
+            { id: "2", to: "/guide/order#receipt", text: "領収書・納品書について" },
+            { id: "3", to: "/guide/order#security", text: "セキュリティについて" },
+            { id: "4", to: "/guide/order#gift", text: "ギフト対応について" },
+            { id: "5", to: "/guide/order#mail", text: "メールについて" }
+          ]} />
+          <SectionTitle text="アフターサービスについて" id='gift' />
+          <LinkList className={styles.guide__content__main__link__list} items={[
+            { id: "1", to: "/guide/order#flow", text: "商品の注文の流れについて" },
+            { id: "2", to: "/guide/order#receipt", text: "領収書・納品書について" },
+            { id: "3", to: "/guide/order#security", text: "セキュリティについて" },
+            { id: "4", to: "/guide/order#gift", text: "ギフト対応について" },
+            { id: "5", to: "/guide/order#mail", text: "メールについて" }
+          ]} />
+          <SectionTitle text="新規登録について" id='mail' />
+          <LinkList className={styles.guide__content__main__link__list} items={[
+            { id: "1", to: "/guide/order#flow", text: "商品の注文の流れについて" },
+            { id: "2", to: "/guide/order#receipt", text: "領収書・納品書について" },
+            { id: "3", to: "/guide/order#security", text: "セキュリティについて" },
+            { id: "4", to: "/guide/order#gift", text: "ギフト対応について" },
+            { id: "5", to: "/guide/order#mail", text: "メールについて" }
+          ]} />
+          <SectionTitle text="その他" id='mail' />
+          <LinkList className={styles.guide__content__main__link__list} items={[
+            { id: "1", to: "/guide/order#flow", text: "商品の注文の流れについて" },
+            { id: "2", to: "/guide/order#receipt", text: "領収書・納品書について" },
+            { id: "3", to: "/guide/order#security", text: "セキュリティについて" },
+            { id: "4", to: "/guide/order#gift", text: "ギフト対応について" },
+            { id: "5", to: "/guide/order#mail", text: "メールについて" }
+          ]} />
+          <SectionTitle text="お問い合わせ" id='mail' />
+          <LinkList className={styles.guide__content__main__link__list} items={[
+            { id: "1", to: "/guide/contact", text: "お問い合わせ" }
+          ]} />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/UserGuide/UserGuide.tsx
+++ b/src/components/UserGuide/UserGuide.tsx
@@ -1,12 +1,10 @@
-
+import { Link } from 'react-router';
 import { UserGuideSidebar } from '../UserGuideSidebar/UserGuideSidebar';
 import { SectionTitle } from '../SectionTitle/SectionTitle';
 import styles from './UserGuide.module.scss';
-import { LinkList } from '../LinkList/LinkList';
 import { userGuide } from '../../constants/guide';
 
 export function UserGuide() {
-
   return (
     <div className={styles.guide}>
       <SectionTitle text="はじめての方へ" />
@@ -14,63 +12,137 @@ export function UserGuide() {
         <UserGuideSidebar />
         <div className={styles.guide__content__main}>
           {userGuide.map(({ id, title, list }) => (
-            <div key={id}>
-              <div id={id}></div>
-              <SectionTitle text={title} />
-              <LinkList className={styles.guide__content__main__link__list} items={list} />
-            </div>
+            <section key={id} className={styles.guide__section}>
+              <SectionTitle text={title} id={id} />
+              {list.map((item) => (
+                <div key={item.id} id={item.id} className={styles.guide__section__item}>
+                  <h4 className={styles.guide__section__item__title}>{item.text}</h4>
+                  <GuideContent sectionId={item.id} />
+                </div>
+              ))}
+            </section>
           ))}
-
-          <SectionTitle text="ご注文について" id='flow' />
-          <LinkList className={styles.guide__content__main__link__list} items={[
-            { id: "/guide/order#flow", to: "/guide/order#flow", text: "商品の注文の流れについて" },
-            { id: "/guide/order#receipt", to: "/guide/order#receipt", text: "領収書・納品書について" },
-            { id: "/guide/order#security", to: "/guide/order#security", text: "セキュリティについて" },
-            { id: "/guide/order#gift", to: "/guide/order#gift", text: "ギフト対応について" },
-            { id: "/guide/order#mail", to: "/guide/order#mail", text: "メールについて" }
-          ]} />
-          <SectionTitle text="お支払いについて" id='receipt' />
-          <LinkList className={styles.guide__content__main__link__list} items={[
-            { id: "/guide/payment#method", to: "/guide/payment#method", text: "お支払い方法について" }
-          ]} />
-          <SectionTitle text="お届けについて" id='security' />
-          <LinkList className={styles.guide__content__main__link__list} items={[
-            { id: "1", to: "/guide/order#flow", text: "商品の注文の流れについて" },
-            { id: "2", to: "/guide/order#receipt", text: "領収書・納品書について" },
-            { id: "3", to: "/guide/order#security", text: "セキュリティについて" },
-            { id: "4", to: "/guide/order#gift", text: "ギフト対応について" },
-            { id: "5", to: "/guide/order#mail", text: "メールについて" }
-          ]} />
-          <SectionTitle text="アフターサービスについて" id='gift' />
-          <LinkList className={styles.guide__content__main__link__list} items={[
-            { id: "1", to: "/guide/order#flow", text: "商品の注文の流れについて" },
-            { id: "2", to: "/guide/order#receipt", text: "領収書・納品書について" },
-            { id: "3", to: "/guide/order#security", text: "セキュリティについて" },
-            { id: "4", to: "/guide/order#gift", text: "ギフト対応について" },
-            { id: "5", to: "/guide/order#mail", text: "メールについて" }
-          ]} />
-          <SectionTitle text="新規登録について" id='mail' />
-          <LinkList className={styles.guide__content__main__link__list} items={[
-            { id: "1", to: "/guide/order#flow", text: "商品の注文の流れについて" },
-            { id: "2", to: "/guide/order#receipt", text: "領収書・納品書について" },
-            { id: "3", to: "/guide/order#security", text: "セキュリティについて" },
-            { id: "4", to: "/guide/order#gift", text: "ギフト対応について" },
-            { id: "5", to: "/guide/order#mail", text: "メールについて" }
-          ]} />
-          <SectionTitle text="その他" id='mail' />
-          <LinkList className={styles.guide__content__main__link__list} items={[
-            { id: "1", to: "/guide/order#flow", text: "商品の注文の流れについて" },
-            { id: "2", to: "/guide/order#receipt", text: "領収書・納品書について" },
-            { id: "3", to: "/guide/order#security", text: "セキュリティについて" },
-            { id: "4", to: "/guide/order#gift", text: "ギフト対応について" },
-            { id: "5", to: "/guide/order#mail", text: "メールについて" }
-          ]} />
-          <SectionTitle text="お問い合わせ" id='mail' />
-          <LinkList className={styles.guide__content__main__link__list} items={[
-            { id: "1", to: "/guide/contact", text: "お問い合わせ" }
-          ]} />
         </div>
       </div>
     </div>
-  )
+  );
 }
+
+function GuideContent({ sectionId }: { sectionId: string }) {
+  if (sectionId === 'contact') {
+    return (
+      <div className={styles.guide__content__text}>
+        ご不明な点がございましたら、
+        <Link to="/contact" className={styles.guide__contact__link}>
+          お問い合わせページ
+        </Link>
+        よりお気軽にご連絡ください。
+      </div>
+    );
+  }
+  const content = guideContents[sectionId as keyof typeof guideContents];
+  return <div className={styles.guide__content__text}>{content}</div>;
+}
+
+const guideContents: Record<string, string> = {
+  flow: `当サイトでのご注文の流れをご説明します。
+
+1. 商品をカートに追加
+お気に入りの商品をカートに追加してください。
+
+2. カートの確認
+カート内の商品・数量・お届け先をご確認ください。
+
+3. お支払い方法の選択
+クレジットカード、銀行振込などからお選びいただけます。
+
+4. ご注文の確定
+内容をご確認の上、ご注文を確定してください。
+
+5. 注文確認メールの送付
+ご注文確定後、確認メールをお送りします。`,
+  receipt: `領収書・納品書について
+
+【領収書】
+ご希望の場合は、お支払い完了後にお届けいたします。ご注文時の備考欄に「領収書希望」とご記入ください。
+
+【納品書】
+商品お届け時に同梱いたします。`,
+  security: `セキュリティについて
+
+当サイトでは、お客様の個人情報を保護するため、SSL（Secure Socket Layer）による暗号化通信を採用しています。クレジットカード情報など、重要なデータは暗号化されて送信されます。`,
+  gift: `ギフト対応について
+
+ギフト包装をご希望の場合は、ご注文時の備考欄にその旨をご記入ください。のし紙のご希望がある場合もあわせてお知らせください。`,
+  mail: `メールについて
+
+ご注文確定後、以下のメールをお送りします。
+・注文確認メール
+・発送完了メール
+
+メールが届かない場合は、迷惑メールフォルダをご確認いただくか、お問い合わせください。`,
+  method: `お支払い方法について
+
+【クレジットカード】
+VISA、Mastercard、JCB、American Expressをご利用いただけます。
+
+【銀行振込】
+ご注文後、7日以内にお振込みください。振込手数料はお客様のご負担となります。
+
+【代金引換】
+商品お届け時に代金をお支払いください。代引手数料が別途かかります。`,
+  shipping: `商品の発送について
+
+【発送時期】
+ご注文確定後、通常3〜7営業日以内に発送いたします。在庫状況により変動する場合がございます。
+
+【配送業者】
+ヤマト運輸、佐川急便など、地域に応じて最適な配送業者でお届けします。`,
+  amount: `送料について
+
+【送料】
+購入金額に応じて送料が異なります。カート画面でご確認ください。
+
+【送料無料】
+一定金額以上のご購入で送料無料となります。`,
+  return: `返品・返金について
+
+【返品期限】
+商品到着後8日以内にご連絡ください。
+
+【返品条件】
+未使用・未開封の商品に限り返品をお受けいたします。
+
+【返金】
+返品確認後、1〜2週間程度でご指定の口座へお振込みいたします。`,
+  register: `会員登録について
+
+会員登録により、以下の特典をご利用いただけます。
+・注文履歴の確認
+・お届け先の登録
+・お気に入り商品の保存
+
+新規登録は無料です。`,
+  login: `ログインID・パスワードについて
+
+【パスワードを忘れた場合】
+ログインページの「パスワードをお忘れの方」より、再設定メールをお送りします。
+
+【ログインできない場合】
+メールアドレスとパスワードに誤りがないかご確認ください。`,
+  change: `登録情報の変更・退会について
+
+【登録情報の変更】
+マイページより、お届け先やメールアドレスなどの変更が可能です。
+
+【退会】
+マイページの設定より退会手続きが可能です。退会後も注文履歴の確認は一定期間可能です。`,
+  environment: `利用環境について
+
+【推奨環境】
+・Windows: Microsoft Edge、Google Chrome（最新版）
+・Mac: Safari、Google Chrome（最新版）
+・スマートフォン: iOS Safari、Android Chrome（最新版）
+
+JavaScriptを有効にしてお使いください。`,
+};

--- a/src/components/UserGuideButtonForHeader/UserGuideButtonForHeader.module.scss
+++ b/src/components/UserGuideButtonForHeader/UserGuideButtonForHeader.module.scss
@@ -1,0 +1,16 @@
+.user__guide__button__container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.user__guide__button {
+  height: auto;
+  padding: 8px 16px;
+  border-radius: 25px;
+  font-family: var(--font-family);
+  font-style: normal;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.5;
+}

--- a/src/components/UserGuideButtonForHeader/UserGuideButtonForHeader.tsx
+++ b/src/components/UserGuideButtonForHeader/UserGuideButtonForHeader.tsx
@@ -1,0 +1,12 @@
+import { PATH } from '../../constants/path';
+import { ButtonLink } from '../ButtonLink/ButtonLink';
+
+import styles from './UserGuideButtonForHeader.module.scss';
+
+export function UserGuideButtonForHeader() {
+  return (
+    <div className={styles.user__guide__button__container}>
+      <ButtonLink className={styles.user__guide__button} to={PATH.GUIDE()} text='ご利用ガイド' white onClick={() => { }} />
+    </div>
+  );
+}

--- a/src/components/UserGuideButtonForRightButtonContainer/UserGuideButtonForRightButtonContainer.module.scss
+++ b/src/components/UserGuideButtonForRightButtonContainer/UserGuideButtonForRightButtonContainer.module.scss
@@ -1,0 +1,12 @@
+.user__guide__button {
+  width: 75px;
+  height: 75px;
+  padding: 8px;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.5;
+  color: var(--text-on-primary-light);
+  background-color: var(--accent-400);
+  border-color: var(--accent-400);
+  border-radius: 50px;
+}

--- a/src/components/UserGuideButtonForRightButtonContainer/UserGuideButtonForRightButtonContainer.tsx
+++ b/src/components/UserGuideButtonForRightButtonContainer/UserGuideButtonForRightButtonContainer.tsx
@@ -1,0 +1,14 @@
+
+import { PATH } from '../../constants/path';
+import { ButtonLink } from '../ButtonLink/ButtonLink';
+import styles from './UserGuideButtonForRightButtonContainer.module.scss';
+
+export function UserGuideButtonForRightButtonContainer() {
+  return (
+    <div>
+      <ButtonLink className={styles.user__guide__button} to={PATH.GUIDE()}>
+        ご利用<br />ガイド
+      </ButtonLink>
+    </div>
+  )
+}

--- a/src/components/UserGuideForFooter/UserGuideForFooter.module.scss
+++ b/src/components/UserGuideForFooter/UserGuideForFooter.module.scss
@@ -1,0 +1,7 @@
+.guide__links {
+
+
+  &__item {
+    margin-bottom: 24px;
+  }
+}

--- a/src/components/UserGuideForFooter/UserGuideForFooter.tsx
+++ b/src/components/UserGuideForFooter/UserGuideForFooter.tsx
@@ -1,0 +1,21 @@
+
+import { userGuide } from "../../constants/guide";
+import { LinkList } from "../LinkList/LinkList";
+import { SectionTitle } from "../SectionTitle/SectionTitle";
+import styles from "./UserGuideForFooter.module.scss";
+
+export const UserGuideForFooter = () => {
+  return (
+    <section className={styles.guide__links}>
+      <SectionTitle text="ご利用ガイド" secondary />
+      <div className={styles.guide__links__content}>
+        {userGuide.map(({ id, title, list }) => (
+          <div key={id} className={styles.guide__links__item}>
+            <SectionTitle text={title} size="small" secondary />
+            <LinkList items={list} secondary />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+};

--- a/src/components/UserGuideForTop/UserGuideForTop.module.scss
+++ b/src/components/UserGuideForTop/UserGuideForTop.module.scss
@@ -1,0 +1,27 @@
+.user__guide__for__top__container {
+  width: var(--container-width);
+  margin: 0 auto 40px;
+}
+
+.user__guide__for__top {
+  padding: 24px 40px;
+  background-color: var(--accent-800);
+  border-radius: 4px;
+  text-align: center;
+
+  &__header {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 8px;
+    font-size: 1.6rem;
+    color: var(--text-on-primary);
+    margin-bottom: 24px;
+  }
+
+  &__content {
+    font-size: 16px;
+    color: var(--text-on-primary);
+    margin-bottom: 24px;
+  }
+}

--- a/src/components/UserGuideForTop/UserGuideForTop.tsx
+++ b/src/components/UserGuideForTop/UserGuideForTop.tsx
@@ -1,0 +1,22 @@
+import { IoNotifications } from "react-icons/io5";
+import { UserGuideButtonForHeader } from '../UserGuideButtonForHeader/UserGuideButtonForHeader';
+import styles from './UserGuideForTop.module.scss';
+
+export function UserGuideForTop() {
+  return (
+    <div className={styles.user__guide__for__top__container}>
+      <div className={styles.user__guide__for__top}>
+        <h3 className={styles.user__guide__for__top__header}>
+          <IoNotifications />
+          サイトの使い方を知る
+        </h3>
+        <div className={styles.user__guide__for__top__content}>
+          初めての方へ、ようこそ。サイトの使い方や注意点をご紹介します。サイトを利用する際に参考にしてください。
+          <br />
+          サイトの使い方を理解することで、より快適にサイトを利用できます。
+        </div>
+        <UserGuideButtonForHeader />
+      </div>
+    </div>
+  )
+}

--- a/src/components/UserGuideSidebar/UserGuideSidebar.module.scss
+++ b/src/components/UserGuideSidebar/UserGuideSidebar.module.scss
@@ -1,0 +1,20 @@
+.sidebar {
+  &__sub__title {
+    font-family: var(--font-family);
+    font-style: normal;
+    font-weight: 400;
+    font-size: 14px;
+    line-height: 1.5;
+    color: var(--text-on-primary-light);
+    cursor: pointer;
+    border-bottom: 1px dotted var(--border-light);
+    padding: 8px 0;
+  }
+
+  &__sub__list {
+    border-bottom: 1px solid var(--border-light);
+    margin: 0;
+    padding: 0;
+    padding-left: 24px;
+  }
+}

--- a/src/components/UserGuideSidebar/UserGuideSidebar.tsx
+++ b/src/components/UserGuideSidebar/UserGuideSidebar.tsx
@@ -1,0 +1,23 @@
+
+import { userGuide } from "../../constants/guide";
+import { SectionTitle } from "../SectionTitle/SectionTitle";
+import { UserGuideSidebarLinkItem } from "../UserGuideSidebarLinkItem/UserGuideSidebarLinkItem";
+import styles from "./UserGuideSidebar.module.scss";
+
+export function UserGuideSidebar() {
+  return (
+    <div className={styles.sidebar}>
+      <SectionTitle text="ご利用ガイド" size="small" />
+      {userGuide.map(({ id, title, list }) => (
+        <div key={id}>
+          <div className={styles.sidebar__sub__title}>{title}</div>
+          <ul className={styles.sidebar__sub__list}>
+            {list.map((list) => (
+              <UserGuideSidebarLinkItem key={list.to} to={list.to} text={list.text} />
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/components/UserGuideSidebarLinkItem/UserGuideSidebarLinkItem.module.scss
+++ b/src/components/UserGuideSidebarLinkItem/UserGuideSidebarLinkItem.module.scss
@@ -1,0 +1,25 @@
+.guide__item {
+  border-bottom: 1px dotted var(--border-light);
+  transition: all 0.2s ease;
+  cursor: pointer;
+
+  &__link {
+    display: block;
+    padding: 8px 0;
+    font-family: var(--font-family);
+    font-style: normal;
+    font-weight: 400;
+    font-size: 14px;
+    line-height: 1.5;
+    color: var(--text-on-primary-light);
+    text-decoration: none;
+  }
+
+  &:hover {
+    opacity: 0.8;
+  }
+
+  &:last-child {
+    border-bottom: none;
+  }
+}

--- a/src/components/UserGuideSidebarLinkItem/UserGuideSidebarLinkItem.tsx
+++ b/src/components/UserGuideSidebarLinkItem/UserGuideSidebarLinkItem.tsx
@@ -1,0 +1,18 @@
+
+import { Link } from "react-router";
+import styles from "./UserGuideSidebarLinkItem.module.scss";
+interface UserGuideSidebarLinkItemProps {
+
+  to: string;
+  text: string;
+}
+
+export function UserGuideSidebarLinkItem(props: UserGuideSidebarLinkItemProps) {
+  return (
+    <li className={styles.guide__item}>
+      <Link className={styles.guide__item__link} to={props.to}>
+        {props.text}
+      </Link>
+    </li>
+  );
+}

--- a/src/constants/guide.ts
+++ b/src/constants/guide.ts
@@ -15,92 +15,56 @@ export const userGuide: UserGuide[] = [
     id: "order",
     title: "ご注文について",
     list: [
-      { id: "flow", to: "/guide/order#flow", text: "商品の注文の流れについて" },
-      {
-        id: "receipt",
-        to: "/guide/order#receipt",
-        text: "領収書・納品書について",
-      },
-      {
-        id: "security",
-        to: "/guide/order#security",
-        text: "セキュリティについて",
-      },
-      { id: "gift", to: "/guide/order#gift", text: "ギフト対応について" },
-      { id: "mail", to: "/guide/order#mail", text: "メールについて" },
+      { id: "flow", to: "/guide#flow", text: "商品の注文の流れについて" },
+      { id: "receipt", to: "/guide#receipt", text: "領収書・納品書について" },
+      { id: "security", to: "/guide#security", text: "セキュリティについて" },
+      { id: "gift", to: "/guide#gift", text: "ギフト対応について" },
+      { id: "mail", to: "/guide#mail", text: "メールについて" },
     ],
   },
   {
     id: "payment",
     title: "お支払いについて",
     list: [
-      {
-        id: "method",
-        to: "/guide/payment#method",
-        text: "お支払い方法について",
-      },
+      { id: "method", to: "/guide#method", text: "お支払い方法について" },
     ],
   },
   {
     id: "delivery",
     title: "お届けについて",
     list: [
-      {
-        id: "shipping",
-        to: "/guide/delivery#shipping",
-        text: "商品の発送について",
-      },
-      { id: "amount", to: "/guide/delivery#amount", text: "送料について" },
+      { id: "shipping", to: "/guide#shipping", text: "商品の発送について" },
+      { id: "amount", to: "/guide#amount", text: "送料について" },
     ],
   },
   {
-    id: "return",
+    id: "after-service",
     title: "アフターサービスについて",
     list: [
-      {
-        id: "return",
-        to: "/guide/after-service#return",
-        text: "返品・返金について",
-      },
+      { id: "return", to: "/guide#return", text: "返品・返金について" },
     ],
   },
   {
     id: "account",
     title: "新規登録について",
     list: [
-      {
-        id: "register",
-        to: "/guide/account#register",
-        text: "会員登録について",
-      },
-      {
-        id: "login",
-        to: "/guide/account#login",
-        text: "ログインID・パスワードについて",
-      },
-      {
-        id: "change",
-        to: "/guide/account#change",
-        text: "登録情報の変更・退会について",
-      },
+      { id: "register", to: "/guide#register", text: "会員登録について" },
+      { id: "login", to: "/guide#login", text: "ログインID・パスワードについて" },
+      { id: "change", to: "/guide#change", text: "登録情報の変更・退会について" },
     ],
   },
   {
     id: "other",
     title: "その他",
     list: [
-      {
-        id: "environment",
-        to: "/guide/other#environment",
-        text: "利用環境について",
-      },
+      { id: "environment", to: "/guide#environment", text: "利用環境について" },
     ],
   },
   {
     id: "contact",
     title: "お問い合わせ",
     list: [
-      { id: "contact", to: "/guide/contact#contact", text: "お問い合わせ" },
+      { id: "contact", to: "/guide#contact", text: "お問い合わせ" },
     ],
   },
 ];

--- a/src/constants/guide.ts
+++ b/src/constants/guide.ts
@@ -1,0 +1,106 @@
+interface UserGuideItem {
+  id: string;
+  to: string;
+  text: string;
+}
+
+export interface UserGuide {
+  id: string;
+  title: string;
+  list: UserGuideItem[];
+}
+
+export const userGuide: UserGuide[] = [
+  {
+    id: "order",
+    title: "ご注文について",
+    list: [
+      { id: "flow", to: "/guide/order#flow", text: "商品の注文の流れについて" },
+      {
+        id: "receipt",
+        to: "/guide/order#receipt",
+        text: "領収書・納品書について",
+      },
+      {
+        id: "security",
+        to: "/guide/order#security",
+        text: "セキュリティについて",
+      },
+      { id: "gift", to: "/guide/order#gift", text: "ギフト対応について" },
+      { id: "mail", to: "/guide/order#mail", text: "メールについて" },
+    ],
+  },
+  {
+    id: "payment",
+    title: "お支払いについて",
+    list: [
+      {
+        id: "method",
+        to: "/guide/payment#method",
+        text: "お支払い方法について",
+      },
+    ],
+  },
+  {
+    id: "delivery",
+    title: "お届けについて",
+    list: [
+      {
+        id: "shipping",
+        to: "/guide/delivery#shipping",
+        text: "商品の発送について",
+      },
+      { id: "amount", to: "/guide/delivery#amount", text: "送料について" },
+    ],
+  },
+  {
+    id: "return",
+    title: "アフターサービスについて",
+    list: [
+      {
+        id: "return",
+        to: "/guide/after-service#return",
+        text: "返品・返金について",
+      },
+    ],
+  },
+  {
+    id: "account",
+    title: "新規登録について",
+    list: [
+      {
+        id: "register",
+        to: "/guide/account#register",
+        text: "会員登録について",
+      },
+      {
+        id: "login",
+        to: "/guide/account#login",
+        text: "ログインID・パスワードについて",
+      },
+      {
+        id: "change",
+        to: "/guide/account#change",
+        text: "登録情報の変更・退会について",
+      },
+    ],
+  },
+  {
+    id: "other",
+    title: "その他",
+    list: [
+      {
+        id: "environment",
+        to: "/guide/other#environment",
+        text: "利用環境について",
+      },
+    ],
+  },
+  {
+    id: "contact",
+    title: "お問い合わせ",
+    list: [
+      { id: "contact", to: "/guide/contact#contact", text: "お問い合わせ" },
+    ],
+  },
+];

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -11,4 +11,5 @@ export const PATH = {
   ME_ORDERS: () => "/me/orders",
   ME_ORDERS_ORDER_ID: (id: string) => `/me/orders/${id}`,
   CONTACT: () => "/contact",
+  GUIDE: () => "/guide",
 };

--- a/src/layouts/Layout.module.scss
+++ b/src/layouts/Layout.module.scss
@@ -1,0 +1,9 @@
+.layout {
+
+
+  .right__button__container {
+    position: fixed;
+    right: 32px;
+    bottom: 32px;
+  }
+}

--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -5,14 +5,20 @@ import Header from '../components/Header/Header';
 import Footer from '../components/Footer/Footer';
 import { ModalCookieConsent } from '../components/ModalCookieConsent/ModalCookieConsent';
 
+import styles from './Layout.module.scss';
+import { UserGuideButtonForRightButtonContainer } from '../components/UserGuideButtonForRightButtonContainer/UserGuideButtonForRightButtonContainer';
+
 export default function Layout() {
 
   return (
-    <>
+    <div className={styles.layout}>
       <Header />
       <Outlet />
       <Footer />
+      <div className={styles.right__button__container}>
+        <UserGuideButtonForRightButtonContainer />
+      </div>
       <ModalCookieConsent />
-    </>
+    </div>
   )
 }

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -62,7 +62,13 @@ export const router = createBrowserRouter([
   },
   {
     path: "/items/:itemId",
-    element: <ItemId />,
+    element: <Layout />,
+    children: [
+      {
+        index: true,
+        element: <ItemId />,
+      },
+    ],
   },
   {
     path: "/cart",

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -13,6 +13,8 @@ import Layout from "./layouts/Layout"
 import { Signup } from "./routes/sign-up/Signup"
 import Top from "./routes/top/Top"
 import { ProtectedRoute } from "./components/ProtectedRoute/ProtectedRoute"
+import Guide from "./routes/guide/Guide"
+import OrderProcessGuide from './routes/guide/OrderProcessGuide'
 
 export const router = createBrowserRouter([
   {
@@ -91,6 +93,20 @@ export const router = createBrowserRouter([
         ],
       },
     ],
+  },
+  {
+    path: "/guide",
+    element: <Layout />,
+    children: [
+      {
+        index: true,
+        element: <Guide />,
+      },
+      {
+        path: "/guide/order-process",
+        element: <OrderProcessGuide />,
+      }
+    ]
   },
   {
     path: "/contact",

--- a/src/routes/guide/Guide.tsx
+++ b/src/routes/guide/Guide.tsx
@@ -1,0 +1,10 @@
+import { UserGuide } from "../../components/UserGuide/UserGuide";
+
+export default function Guide() {
+
+  return (
+    <>
+      <UserGuide />
+    </>
+  )
+}

--- a/src/routes/guide/OrderProcessGuide.tsx
+++ b/src/routes/guide/OrderProcessGuide.tsx
@@ -1,0 +1,7 @@
+
+export default function OrderProcessGuide() {
+
+  return (
+    <div>商品の注文の流れについて</div>
+  )
+}

--- a/src/routes/items/itemId/ItemId.module.scss
+++ b/src/routes/items/itemId/ItemId.module.scss
@@ -1,0 +1,42 @@
+.itemId {
+  width: var(--container-width);
+  margin: 40px auto 120px;
+
+  &__content {
+    padding: 20px 0;
+  }
+
+  &__cart__area {
+    margin-top: 24px;
+    padding: 16px 0;
+    border-top: 1px solid #eee;
+  }
+
+  &__cart__button {
+    display: inline-block;
+    padding: 12px 24px;
+    background-color: var(--color-primary, #0066cc);
+    color: white;
+    text-decoration: none;
+    border-radius: 4px;
+    font-weight: 600;
+
+    &:hover {
+      opacity: 0.9;
+    }
+  }
+
+  &__guide__link {
+    margin-top: 12px;
+    font-size: 0.875rem;
+
+    &__anchor {
+      color: var(--color-primary, #0066cc);
+      text-decoration: underline;
+
+      &:hover {
+        text-decoration: none;
+      }
+    }
+  }
+}

--- a/src/routes/items/itemId/ItemId.tsx
+++ b/src/routes/items/itemId/ItemId.tsx
@@ -1,7 +1,26 @@
+import { Link, useParams } from 'react-router';
+import { PATH } from '../../../constants/path';
+import styles from './ItemId.module.scss';
 
 export default function ItemId() {
+  const { itemId } = useParams();
 
   return (
-    <div>ItemId</div>
-  )
+    <main className={styles.itemId}>
+      <div className={styles.itemId__content}>
+        <h1>商品詳細 {itemId}</h1>
+        <p>商品情報はこちらに表示されます。</p>
+        <div className={styles.itemId__cart__area}>
+          <Link to={PATH.CART()} className={styles.itemId__cart__button}>
+            カートに追加
+          </Link>
+          <p className={styles.itemId__guide__link}>
+            <Link to={PATH.GUIDE()} className={styles.itemId__guide__link__anchor}>
+              ご利用ガイドはこちら
+            </Link>
+          </p>
+        </div>
+      </div>
+    </main>
+  );
 }

--- a/src/routes/top/Top.tsx
+++ b/src/routes/top/Top.tsx
@@ -7,6 +7,7 @@ import { RankingList } from "../../components/RankingList/RankingList";
 import mainVisualImage1 from '@/assets/images/main-visual_1.png';
 import itemImage1 from '@/assets/images/linked-item_1.png';
 import rankingItemImage1 from '@/assets/images/ranking-item_1.png';
+import { UserGuideForTop } from "../../components/UserGuideForTop/UserGuideForTop";
 
 export default function Top() {
 
@@ -73,6 +74,7 @@ export default function Top() {
   return (
     <main>
       <MainVisual items={mainVisualItems} />
+      <UserGuideForTop />
       <CouponApplicableItemList items={couponApplicableItems} />
       <RecommendItemList items={recommendItems} />
       <SearchByCategory items={searchByCategoryItems} />


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## Ticket / Issue Number

- #81 

## 変更内容

- ご利用ガイド画面を追加した
- ご利用ガイドへのリンクを追加した
  - ヘッダーメニューへの設置
  - フッターに各種利用ガイド見出しリンクを設置
  - スクロールに影響しないガイドメニューを設置
  - 商品ページにカートボタン付近にテキストリンクを設置
  - TOPページに「初めての方へ」のリンクを設置

# 影響範囲


## タスク


## チェックリスト

- [ ] CI/CD のビルドが正常に動作していること
- [ ] SonarQubeCloud が成功していること
- [ ] 相応したテストケースを書きました

## 補足

レビューをする際に見てほしい点、ローカル環境で試す際の注意点など補足事項があれば記入してください

<!-- for GitHub Copilot review rule -->
<!--
レビューする際には、以下のprefix(接頭辞)をつけてください
[must]
[imo] (in my opinion)
[nits](nitpick)
[ask]
[fyi]
-->
<!-- for GitHub Copilot review  rule-->

<!-- I want to review in Japanese. -->
